### PR TITLE
Add resetting high scores, fix some bugs

### DIFF
--- a/source/main.lua
+++ b/source/main.lua
@@ -302,6 +302,12 @@ function titleScreenLogic()
     if playdate.buttonJustPressed(playdate.kButtonA) then
         gameState = start
     end
+
+    -- reset scores by pressing Up and B at same time
+    if playdate.buttonJustPressed(playdate.kButtonUp) and playdate.buttonJustPressed(playdate.kButtonB) then
+        highestScores = {}
+        highestScoresLength = 0
+    end
 end
 
 function duck()

--- a/source/main.lua
+++ b/source/main.lua
@@ -154,6 +154,9 @@ function reset()
     end
     groundSprite:remove()
     gameState = title
+    grounded = true
+    airAcceleration = gravity
+    velocity = 0
 end
 
 -- This whole function seems redundant, but apparently Lua does not have a good way to get the length of a table

--- a/source/main.lua
+++ b/source/main.lua
@@ -180,7 +180,7 @@ function addHighScore()
         -- person got a score, but does it beat any score on the leaderboard?
         local newScore = false
         for i in pairs(highestScores) do
-            if score >= highestScores[i][2] or numOfHighScores() < maxHighScores then
+            if score > highestScores[i][2] or numOfHighScores() < maxHighScores then
                 newScore = true
                 break
             end
@@ -193,14 +193,15 @@ function addHighScore()
             end) -- sorts in decending order
 
             -- ensure number of high scores is limited
-            if numOfHighScores() > maxHighScores then
+            if numOfHighScores() >= maxHighScores then
                 highestScores[maxHighScores + 1] = nil
             end
 
             gfx.drawText("NEW HIGH SCORE!", 180, 60)
+            return
         end
 
-        return
+        gfx.drawText("YOU LOSER!", 200, 60)
     end
 
     gfx.drawText("YOU LOSER!", 200, 60)


### PR DESCRIPTION
You can now reset the leaderboard. To do this press Up and B at the same time on the title screen.

If you hit into an obstacle while in the jumping sequence, the jumping animation will not persist after restarting. This was done by resetting the variables related to jumping in reset().

High scores are now actually limited to 5. The issue here was actually much stupider than I was thinking, it was due to improper use of greater/less than vs greater/less than or equal to. Also the high score msg was erroneously showing when getting a normal score (solved using an extra return statement)

Fixes #10 #12 #13 