### PR TITLE
Addition of floating obstacles

### DIFF
--- a/source/main.lua
+++ b/source/main.lua
@@ -125,8 +125,20 @@ end
 
 function createObstacles ()
     local baseX = 400; -- this is the edge of the playdate screen, but it could be something else
-    
+    local randNum = 0
+
     for i = 1, groundObstacleCount, 1 do
+        -- generate a random number between 0 and 100
+        randNum = math.random(0, 100)
+
+        -- set the y value based on the random number
+        -- 30% chance of y value being at 140 (above ground) 
+        -- 70% chance of y value being at 160 (at ground level)
+        local valueY = 160
+        if randNum >= 70 then
+            valueY = 140
+        end
+
         -- generate x coords for obstacles
         groundObstacleXValues[i] = math.random(baseX, baseX + 50)
         baseX += 175
@@ -138,7 +150,7 @@ function createObstacles ()
         end
 
         -- move to starting position (can be used to reposition)
-        groundObstacles[i]:moveTo(groundObstacleXValues[i], 160)
+        groundObstacles[i]:moveTo(groundObstacleXValues[i], valueY)
     end
 end
 

--- a/source/main.lua
+++ b/source/main.lua
@@ -124,7 +124,7 @@ function drawBase ()
 end
 
 function createObstacles ()
-    local baseX = 400; -- this is the edge of the playdate screen, but it could be something else
+    local baseX = 400 -- this is the edge of the playdate screen, but it could be something else
     local randNum = 0
 
     for i = 1, groundObstacleCount, 1 do
@@ -151,6 +151,17 @@ function createObstacles ()
 
         -- move to starting position (can be used to reposition)
         groundObstacles[i]:moveTo(groundObstacleXValues[i], valueY)
+        
+        -- if randNum is greater than 95, stack multiple obstacles on top of each other
+        -- so that the player must duck (5% chance of this occurring, will occur during above ground obstacle placement)
+        if randNum >= 95 then
+            for j = 1, 2 do
+                local stackedObstacle = gfx.sprite.new(groundObstacleImage)
+                stackedObstacle:setCollideRect(0, 0, stackedObstacle:getSize())
+                stackedObstacle:moveTo(groundObstacleXValues[i], valueY - 30 * j) -- stack on top
+                table.insert(groundObstacles, stackedObstacle)
+            end
+        end
     end
 end
 

--- a/source/main.lua
+++ b/source/main.lua
@@ -31,6 +31,7 @@ local maxGroundObstacleSpeed <const> = -5
 local groundObstacles = {}  -- holds all obstacles, we do this because we need to keep track of multiple obstacles
 local groundObstacleXValues = {}
 local addedGroundObstacleSpeed = 0
+local tallObstacle = false
 
 -- for jumping
 local grounded = true -- refers to player
@@ -146,10 +147,16 @@ function createObstacles ()
 
         -- create obstacle if not exist
         if groundObstacles[i] == nil then
-            -- 5% chance of obstacle being taller, so use taller sprite and adjust position
-            if randNum >= 95 then
-                groundObstacles[i] = gfx.sprite.new(groundObstacleImage2)
-                valueY = 115
+            -- Only display tall obstacle once per round
+            if not tallObstacle then
+                -- 5% chance of obstacle being taller, so use taller sprite and adjust position
+                if randNum >= 95 then
+                    groundObstacles[i] = gfx.sprite.new(groundObstacleImage2)
+                    valueY = 115
+                    tallObstacle = true
+                else
+                    groundObstacles[i] = gfx.sprite.new(groundObstacleImage)
+                end
             else
                 groundObstacles[i] = gfx.sprite.new(groundObstacleImage)
             end
@@ -174,6 +181,7 @@ function reset ()
     groundObstacles = {}
     groundSprite:remove()
     gameState = title
+    tallObstacle = false
 end
 
 -- This whole function seems redundant, but apparently Lua does not have a good way to get the length of a table

--- a/source/main.lua
+++ b/source/main.lua
@@ -24,7 +24,6 @@ local groundSprite <const> = gfx.sprite.new(groundImage)
 
 -- create ground obstacles player jumps over
 local groundObstacleImage <const> = gfx.image.new(20, 30, gfx.kColorBlack)
-local groundObstacleImage2 <const> = gfx.image.new(20, 80, gfx.kColorBlack)
 local groundObstacleCount <const> = 5  -- amount of obstacles in each "round"
 local baseGroundObstacleSpeed <const> = -2  -- obstacles are moving left, so this is negative
 
@@ -32,7 +31,6 @@ local maxGroundObstacleSpeed <const> = -5
 local groundObstacles = {} -- holds all obstacles, we do this because we need to keep track of multiple obstacles
 local groundObstacleXValues = {}
 local addedGroundObstacleSpeed = 0
-local tallObstacle = false
 
 -- for jumping
 local grounded = true -- refers to player
@@ -149,22 +147,9 @@ function createObstacles ()
 
         -- create obstacle if not exist
         if groundObstacles[i] == nil then
-            -- Only display tall obstacle once per round
-            if not tallObstacle then
-                -- 5% chance of obstacle being taller, so use taller sprite and adjust position
-                if randNum >= 95 then
-                    groundObstacles[i] = gfx.sprite.new(groundObstacleImage2)
-                    valueY = 115
-                    tallObstacle = true
-                else
-                    groundObstacles[i] = gfx.sprite.new(groundObstacleImage)
-                end
-            else
-                groundObstacles[i] = gfx.sprite.new(groundObstacleImage)
-            end
+            groundObstacles[i] = gfx.sprite.new(groundObstacleImage)
             groundObstacles[i]:setCollideRect(0, 0, groundObstacles[i]:getSize())
         end
-
         -- move to starting position (can be used to reposition)
         groundObstacles[i]:moveTo(groundObstacleXValues[i], valueY)
     end
@@ -183,7 +168,6 @@ function reset()
     groundObstacles = {}
     groundSprite:remove()
     gameState = title
-    tallObstacle = false
 end
 
 -- This whole function seems redundant, but apparently Lua does not have a good way to get the length of a table

--- a/source/main.lua
+++ b/source/main.lua
@@ -24,6 +24,7 @@ local groundSprite <const> = gfx.sprite.new(groundImage)
 
 -- create ground obstacles player jumps over
 local groundObstacleImage <const> = gfx.image.new(20, 30, gfx.kColorBlack)
+local groundObstacleImage2 <const> = gfx.image.new(20, 80, gfx.kColorBlack)
 local groundObstacleCount <const> = 5  -- amount of obstacles in each "round"
 local baseGroundObstacleSpeed <const> = -2  -- obstacles are moving left, so this is negative
 local maxGroundObstacleSpeed <const> = -5
@@ -145,23 +146,18 @@ function createObstacles ()
 
         -- create obstacle if not exist
         if groundObstacles[i] == nil then
-            groundObstacles[i] = gfx.sprite.new(groundObstacleImage)
+            -- 5% chance of obstacle being taller, so use taller sprite and adjust position
+            if randNum >= 95 then
+                groundObstacles[i] = gfx.sprite.new(groundObstacleImage2)
+                valueY = 115
+            else
+                groundObstacles[i] = gfx.sprite.new(groundObstacleImage)
+            end
             groundObstacles[i]:setCollideRect(0, 0, groundObstacles[i]:getSize())
         end
 
         -- move to starting position (can be used to reposition)
         groundObstacles[i]:moveTo(groundObstacleXValues[i], valueY)
-        
-        -- if randNum is greater than 95, stack multiple obstacles on top of each other
-        -- so that the player must duck (5% chance of this occurring, will occur during above ground obstacle placement)
-        if randNum >= 95 then
-            for j = 1, 2 do
-                local stackedObstacle = gfx.sprite.new(groundObstacleImage)
-                stackedObstacle:setCollideRect(0, 0, stackedObstacle:getSize())
-                stackedObstacle:moveTo(groundObstacleXValues[i], valueY - 30 * j) -- stack on top
-                table.insert(groundObstacles, stackedObstacle)
-            end
-        end
     end
 end
 
@@ -175,6 +171,7 @@ function reset ()
     for i in pairs(groundObstacles) do
         groundObstacles[i]:remove()
     end
+    groundObstacles = {}
     groundSprite:remove()
     gameState = title
 end


### PR DESCRIPTION
During a round, there is now the potential for both ground obstacles and floating ones to duck under to be generated. There is a higher chance of encountering ground obstacles compared to floating ones, using a fairly simple random number implementation. Additionally, there is a 5% chance that the player will encounter a much taller obstacle once per round that they are forced to duck under. fixes #7 