### PR TITLE
Debugger, Gitignore Whitelist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,13 @@
 # whitelist system
 
 # ignore everything
-*
+/*
 
-# except:
-!\.vscode\*
-!\source\*
-!\LICENSE
-!\README.*
+# except these:
+!/.vscode
+!/.vscode/*
+!/source
+!/source/*
+!/.gitignore
+!/LICENSE
+!/README.*

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
-\output.pdx
-\.vscode\*
-!\.vscode\settings.json
-!\.vscode\launch.json
-.luarc.json
-.editorconfig
+# whitelist system
+
+# ignore everything
+*
+
+# except:
+!\.vscode\*
+!\source\*
+!\LICENSE
+!\README.*

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,7 +4,8 @@
         {
             "request": "launch",
             "type": "playdate",
-            "name": "Run app in Playdate simulator",
+            "name": "Playdate: Debug",
+            "preLaunchTask": "${defaultBuildTask}",
             "source": "${workspaceRoot}/source",
             "output": "${workspaceRoot}/output.pdx",
             // Optionally set sdkPath if not PLAYDATE_SDK_PATH is configured.

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,25 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+      {
+        "type": "pdc",
+        "problemMatcher": ["$pdc-lua", "$pdc-external"],
+        "label": "Playdate: Build"
+      },
+      {
+        "type": "playdate-simulator",
+        "problemMatcher": ["$pdc-external"],
+        "label": "Playdate: Run"
+      },
+      {
+        "label": "Playdate: Build and Run",
+        "dependsOn": ["Playdate: Build", "Playdate: Run"],
+        "dependsOrder": "sequence",
+        "problemMatcher": [],
+        "group": {
+          "kind": "build",
+          "isDefault": true
+        }
+      }
+    ]
+  }

--- a/README.MD
+++ b/README.MD
@@ -58,5 +58,5 @@ At this point, try running the Playdate Simulator to ensure it works. If it does
 
 ### Final Setup
 
-- In VS Code, install the Playdate extension [here](https://marketplace.visualstudio.com/items?itemName=Orta.playdate).
+- In VS Code, install the Playdate extension [here](https://marketplace.visualstudio.com/items?itemName=Orta.playdate), and, optionally, the Playdate Debugger extension [here](https://marketplace.visualstudio.com/items?itemName=midouest.playdate-debug) (for debugging tools). 
 - Clone the repo and open it in VS Code. If all went well, press Start Debugging (default key is F5) to run the game!


### PR DESCRIPTION
changes files in the `.vscode` folder to now work with the playdate debugger extension, changed `.gitignore` to work as a whitelist instead of a blacklist